### PR TITLE
feat: added lambda processing instead of returning a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ val someApi = TODO("Not a real API object")
 // Returns a playlist in the M3U format
 val m3uContent: String = someApi.getPlaylist("Best of Willy Astor")
 val entries: List<M3uEntry> = M3uParser.parse(m3uContent)
+
+
+// You can also use a lambda for processing each entry instead of returning a List
+val m3uFile = Paths.get("myplaylist.m3u")
+M3uParser.parse(m3uFile) { entry ->
+    println(entry->name)
+}
+
 ```
 
 ### Nested playlists

--- a/buildConfig/detekt.yml
+++ b/buildConfig/detekt.yml
@@ -3,3 +3,8 @@ comments:
     active: true
   UndocumentedPublicFunction:
     active: true
+complexity:
+  TooManyFunctions:
+    ignoreOverridden: true
+    thresholdInClasses: 15
+    thresholdInObjects: 15

--- a/src/test/kotlin/net/bjoernpetersen/m3u/M3uParserExampleTest.kt
+++ b/src/test/kotlin/net/bjoernpetersen/m3u/M3uParserExampleTest.kt
@@ -124,6 +124,36 @@ class M3uParserExampleTest {
         assertEquals("https://i.imgur.com/CnIVW9o.jpg", withLogo.metadata.logo)
     }
 
+    @TestFactory
+    fun testWikiLambda(): List<DynamicTest> {
+        return listOf(
+            "wiki_mixed.m3u",
+            "wiki_mixed_empty_lines.m3u",
+        ).map { name ->
+            dynamicTest(name) {
+                val entries = mutableListOf<M3uEntry>()
+                M3uParser.parse(javaClass.getResourceAsStream(name).reader()) { entry ->
+                    entries.add(entry)
+                }
+                assertEquals(7, entries.size)
+
+                val simple = listOf(entries[1], entries[4])
+                simple.forEach {
+                    assertThat(it)
+                        .returns(null, M3uEntry::duration)
+                        .returns(null, M3uEntry::title)
+                }
+
+                val extended = entries.filterNot { it in simple }
+                extended.forEach { entry ->
+                    assertThat(entry)
+                        .matches { it.duration != null }
+                        .matches { it.title != null }
+                }
+            }
+        }
+    }
+
     @Test
     fun testRecursiveResolution() {
         val files = listOf("rec_1.m3u", "rec_2.m3u", "rec_3.m3u")


### PR DESCRIPTION
I added lambda processing to the parsing methods. 

These methods are beneficial in some cases like:

* When working with large playlists, memory can become a bottleneck.
* You may not want to have the whole list but trying to filter out some elements.
